### PR TITLE
Fixes #660: Improve typing/logic for `options` in decode, decode_complete; Improve docs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,11 +12,13 @@ Fixed
 - Validate key against allowed types for Algorithm family in `#964 <https://github.com/jpadilla/pyjwt/pull/964>`__
 - Add iterator for JWKSet in `#1041 <https://github.com/jpadilla/pyjwt/pull/1041>`__
 - Validate `iss` claim is a string during encoding and decoding by @pachewise in `#1040 <https://github.com/jpadilla/pyjwt/pull/1040>`__
+- Improve typing/logic for `options` in decode, decode_complete by @pachewise in `#1045 <https://github.com/jpadilla/pyjwt/pull/1045>`__
 
 Added
 ~~~~~
 
 - Docs: Add example of using leeway with nbf by @djw8605 in `#1034 <https://github.com/jpadilla/pyjwt/pull/1034>`__
+- Docs: Refactored docs with ``autodoc``; added ``PyJWS`` and ``jwt.algorithms`` docs by @pachewise in `#1045 <https://github.com/jpadilla/pyjwt/pull/1045>`__
 
 `v2.10.1 <https://github.com/jpadilla/pyjwt/compare/2.10.0...2.10.1>`__
 -----------------------------------------------------------------------

--- a/jwt/algorithms.py
+++ b/jwt/algorithms.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import hashlib
 import hmac
 import json
+import os
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any, ClassVar, Literal, NoReturn, cast, overload
 
@@ -91,32 +92,36 @@ try:
         Ed448PublicKey,
     )
 
+    if TYPE_CHECKING or bool(os.getenv("SPHINX_BUILD", "")):
+        from typing import TypeAlias
+
+        from cryptography.hazmat.primitives.asymmetric.types import (
+            PrivateKeyTypes,
+            PublicKeyTypes,
+        )
+
+        # Type aliases for convenience in algorithms method signatures
+        AllowedRSAKeys: TypeAlias = RSAPrivateKey | RSAPublicKey
+        AllowedECKeys: TypeAlias = EllipticCurvePrivateKey | EllipticCurvePublicKey
+        AllowedOKPKeys: TypeAlias = (
+            Ed25519PrivateKey | Ed25519PublicKey | Ed448PrivateKey | Ed448PublicKey
+        )
+        AllowedKeys: TypeAlias = AllowedRSAKeys | AllowedECKeys | AllowedOKPKeys
+        #: Type alias for allowed ``cryptography`` private keys (requires ``cryptography`` to be installed)
+        AllowedPrivateKeys: TypeAlias = (
+            RSAPrivateKey
+            | EllipticCurvePrivateKey
+            | Ed25519PrivateKey
+            | Ed448PrivateKey
+        )
+        #: Type alias for allowed ``cryptography`` public keys (requires ``cryptography`` to be installed)
+        AllowedPublicKeys: TypeAlias = (
+            RSAPublicKey | EllipticCurvePublicKey | Ed25519PublicKey | Ed448PublicKey
+        )
+
     has_crypto = True
 except ModuleNotFoundError:
     has_crypto = False
-
-
-if TYPE_CHECKING:
-    from typing import TypeAlias
-
-    from cryptography.hazmat.primitives.asymmetric.types import (
-        PrivateKeyTypes,
-        PublicKeyTypes,
-    )
-
-    # Type aliases for convenience in algorithms method signatures
-    AllowedRSAKeys: TypeAlias = RSAPrivateKey | RSAPublicKey
-    AllowedECKeys: TypeAlias = EllipticCurvePrivateKey | EllipticCurvePublicKey
-    AllowedOKPKeys: TypeAlias = (
-        Ed25519PrivateKey | Ed25519PublicKey | Ed448PrivateKey | Ed448PublicKey
-    )
-    AllowedKeys: TypeAlias = AllowedRSAKeys | AllowedECKeys | AllowedOKPKeys
-    AllowedPrivateKeys: TypeAlias = (
-        RSAPrivateKey | EllipticCurvePrivateKey | Ed25519PrivateKey | Ed448PrivateKey
-    )
-    AllowedPublicKeys: TypeAlias = (
-        RSAPublicKey | EllipticCurvePublicKey | Ed25519PublicKey | Ed448PublicKey
-    )
 
 
 requires_cryptography = {
@@ -139,7 +144,7 @@ def get_default_algorithms() -> dict[str, Algorithm]:
     """
     Returns the algorithms that are implemented by the library.
     """
-    default_algorithms = {
+    default_algorithms: dict[str, Algorithm] = {
         "none": NoneAlgorithm(),
         "HS256": HMACAlgorithm(HMACAlgorithm.SHA256),
         "HS384": HMACAlgorithm(HMACAlgorithm.SHA384),
@@ -202,13 +207,12 @@ class Algorithm(ABC):
     def check_crypto_key_type(self, key: PublicKeyTypes | PrivateKeyTypes):
         """Check that the key belongs to the right cryptographic family.
 
-        Note that this method only works when `cryptography` is installed.
+        Note that this method only works when ``cryptography`` is installed.
 
-        Args:
-            key (Any): Potentially a cryptography key
-        Raises:
-            ValueError: if `cryptography` is not installed, or this method is called by a non-cryptography algorithm
-            InvalidKeyError: if the key doesn't match the expected key classes
+        :param key: Potentially a cryptography key
+        :type key: :py:data:`PublicKeyTypes <cryptography.hazmat.primitives.asymmetric.types.PublicKeyTypes>` | :py:data:`PrivateKeyTypes <cryptography.hazmat.primitives.asymmetric.types.PrivateKeyTypes>`
+        :raises ValueError: if ``cryptography`` is not installed, or this method is called by a non-cryptography algorithm
+        :raises InvalidKeyError: if the key doesn't match the expected key classes
         """
         if not has_crypto or self._crypto_key_types is None:
             raise ValueError(

--- a/jwt/api_jwk.py
+++ b/jwt/api_jwk.py
@@ -17,6 +17,16 @@ from .types import JWKDict
 
 class PyJWK:
     def __init__(self, jwk_data: JWKDict, algorithm: str | None = None) -> None:
+        """A class that represents a `JSON Web Key <https://www.rfc-editor.org/rfc/rfc7517>`_.
+
+        :param jwk_data: The decoded JWK data.
+        :type jwk_data: dict[str, typing.Any]
+        :param algorithm: The key algorithm. If not specified, the key's ``alg`` will be used.
+        :type algorithm: str or None
+        :raises InvalidKeyError: If the key type (``kty``) is not found or unsupported, or if the curve (``crv``) is not found or unsupported.
+        :raises MissingCryptographyError: If the algorithm requires ``cryptography`` to be installed and it is not available.
+        :raises PyJWKError: If unable to find an algorithm for the key.
+        """
         self._algorithms = get_default_algorithms()
         self._jwk_data = jwk_data
 
@@ -71,23 +81,52 @@ class PyJWK:
 
     @staticmethod
     def from_dict(obj: JWKDict, algorithm: str | None = None) -> PyJWK:
+        """Creates a :class:`PyJWK` object from a JSON-like dictionary.
+
+        :param obj: The JWK data, as a dictionary
+        :type obj: dict[str, typing.Any]
+        :param algorithm: The key algorithm. If not specified, the key's ``alg`` will be used.
+        :type algorithm: str or None
+        :rtype: PyJWK
+        """
         return PyJWK(obj, algorithm)
 
     @staticmethod
     def from_json(data: str, algorithm: None = None) -> PyJWK:
+        """Create a :class:`PyJWK` object from a JSON string.
+        Implicitly calls :meth:`PyJWK.from_dict()`.
+
+        :param str data: The JWK data, as a JSON string.
+        :param algorithm:  The key algorithm.  If not specific, the key's ``alg`` will be used.
+        :type algorithm: str or None
+
+        :rtype: PyJWK
+        """
         obj = json.loads(data)
         return PyJWK.from_dict(obj, algorithm)
 
     @property
     def key_type(self) -> str | None:
+        """The `kty` property from the JWK.
+
+        :rtype: str or None
+        """
         return self._jwk_data.get("kty", None)
 
     @property
     def key_id(self) -> str | None:
+        """The `kid` property from the JWK.
+
+        :rtype: str or None
+        """
         return self._jwk_data.get("kid", None)
 
     @property
     def public_key_use(self) -> str | None:
+        """The `use` property from the JWK.
+
+        :rtype: str or None
+        """
         return self._jwk_data.get("use", None)
 
 

--- a/jwt/exceptions.py
+++ b/jwt/exceptions.py
@@ -7,46 +7,71 @@ class PyJWTError(Exception):
 
 
 class InvalidTokenError(PyJWTError):
+    """Base exception when ``decode()`` fails on a token"""
+
     pass
 
 
 class DecodeError(InvalidTokenError):
+    """Raised when a token cannot be decoded because it failed validation"""
+
     pass
 
 
 class InvalidSignatureError(DecodeError):
+    """Raised when a token's signature doesn't match the one provided as part of
+    the token."""
+
     pass
 
 
 class ExpiredSignatureError(InvalidTokenError):
+    """Raised when a token's ``exp`` claim indicates that it has expired"""
+
     pass
 
 
 class InvalidAudienceError(InvalidTokenError):
+    """Raised when a token's ``aud`` claim does not match one of the expected
+    audience values"""
+
     pass
 
 
 class InvalidIssuerError(InvalidTokenError):
+    """Raised when a token's ``iss`` claim does not match the expected issuer"""
+
     pass
 
 
 class InvalidIssuedAtError(InvalidTokenError):
+    """Raised when a token's ``iat`` claim is non-numeric"""
+
     pass
 
 
 class ImmatureSignatureError(InvalidTokenError):
+    """Raised when a token's ``nbf`` or ``iat`` claims represent a time in the future"""
+
     pass
 
 
 class InvalidKeyError(PyJWTError):
+    """Raised when the specified key is not in the proper format"""
+
     pass
 
 
 class InvalidAlgorithmError(InvalidTokenError):
+    """Raised when the specified algorithm is not recognized by PyJWT"""
+
     pass
 
 
 class MissingRequiredClaimError(InvalidTokenError):
+    """Raised when a claim that is required to be present is not contained
+    in the claimset"""
+
     def __init__(self, claim: str) -> None:
         self.claim = claim
 
@@ -59,6 +84,8 @@ class PyJWKError(PyJWTError):
 
 
 class MissingCryptographyError(PyJWKError):
+    """Raised if the algorithm requires ``cryptography`` to be installed and it is not available."""
+
     pass
 
 
@@ -75,8 +102,12 @@ class PyJWKClientConnectionError(PyJWKClientError):
 
 
 class InvalidSubjectError(InvalidTokenError):
+    """Raised when a token's ``sub`` claim is not a string or doesn't match the expected ``subject``"""
+
     pass
 
 
 class InvalidJTIError(InvalidTokenError):
+    """Raised when a token's ``jti`` claim is not a string"""
+
     pass

--- a/jwt/types.py
+++ b/jwt/types.py
@@ -1,5 +1,64 @@
-from typing import Any, Callable, Dict
+from typing import Any, Callable, Dict, TypedDict
 
 JWKDict = Dict[str, Any]
 
 HashlibHash = Callable[..., Any]
+
+
+class SigOptions(TypedDict):
+    """Options for PyJWS class (TypedDict). Note that this is a smaller set of options than
+    for :py:func:`jwt.decode()`."""
+
+    verify_signature: bool
+    """verify the JWT cryptographic signature"""
+
+
+class Options(TypedDict, total=False):
+    """Options for :py:func:`jwt.decode()` and :py:func:`jwt.api_jwt.decode_complete()` (TypedDict).
+
+    .. warning::
+
+        Some claims, such as ``exp``, ``iat``, ``jti``, ``nbf``, and ``sub``,
+        will only be verified if present. Please refer to the documentation below
+        for which ones, and make sure to include them in the ``require`` param
+        if you want to make sure that they are always present (and therefore always verified
+        if ``verify_{claim} = True`` for that claim).
+    """
+
+    verify_signature: bool
+    """Default: ``True``. Verify the JWT cryptographic signature."""
+    require: list[str]
+    """Default: ``[]``. List of claims that must be present.
+          Example: ``require=["exp", "iat", "nbf"]``.
+          **Only verifies that the claims exists**. Does not verify that the claims are valid."""
+    strict_aud: bool
+    """Default: ``False``. (requires ``verify_aud=True``) Check that the ``aud`` claim is a single value (not a list), and matches ``audience`` exactly."""
+    verify_aud: bool
+    """Default: ``verify_signature``. Check that ``aud`` (audience) claim matches ``audience``."""
+    verify_exp: bool
+    """Default: ``verify_signature``. Check that ``exp`` (expiration) claim value is in the future (if present in payload). """
+    verify_iat: bool
+    """Default: ``verify_signature``. Check that ``iat`` (issued at) claim value is an integer (if present in payload). """
+    verify_iss: bool
+    """Default: ``verify_signature``. Check that ``iss`` (issuer) claim matches ``issuer``. """
+    verify_jti: bool
+    """Default: ``verify_signature``. Check that ``jti`` (JWT ID) claim is a string (if present in payload). """
+    verify_nbf: bool
+    """Default: ``verify_signature``. Check that ``nbf`` (not before) claim value is in the past (if present in payload). """
+    verify_sub: bool
+    """Default: ``verify_signature``. Check that ``sub`` (subject) claim is a string and matches ``subject`` (if present in payload). """
+
+
+# The only difference between Options and FullOptions is that FullOptions
+# required _every_ value to be there; Options doesn't require any
+class FullOptions(TypedDict):
+    verify_signature: bool
+    require: list[str]
+    strict_aud: bool
+    verify_aud: bool
+    verify_exp: bool
+    verify_iat: bool
+    verify_iss: bool
+    verify_jti: bool
+    verify_nbf: bool
+    verify_sub: bool

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,7 +79,7 @@ source = [
 
 [tool.coverage.report]
 exclude_lines = [
-    "if TYPE_CHECKING:",
+    "if TYPE_CHECKING",
     "pragma: no cover",
 ]
 show_missing = true

--- a/tests/test_api_jwt.py
+++ b/tests/test_api_jwt.py
@@ -36,6 +36,14 @@ def payload():
 
 
 class TestJWT:
+    def test_jwt_with_options(self):
+        jwt = PyJWT(options={"verify_signature": False})
+        assert jwt.options["verify_signature"] is False
+        # assert that unrelated option is unchanged from default
+        assert jwt.options["strict_aud"] is False
+        # assert that verify_signature is respected unless verify_exp is overridden
+        assert jwt.options["verify_exp"] is False
+
     def test_decodes_valid_jwt(self, jwt):
         example_payload = {"hello": "world"}
         example_secret = "secret"


### PR DESCRIPTION
Recreated from original PR: https://github.com/jpadilla/pyjwt/pull/1045

Basically trying to remove "Unknown" or "partially unknown" pylance issues. Mostly with `options`, but there were a few simple other fixes (kwargs, segments, etc). This showed some minor bugs and a few code smells (passing too many args to `api_jws.decode_complete`, for example).

- [x] We should include Options / SigOptions / FullOptions in the docs somehow
- [x] `PyJWT()` is used as a singleton. Do we want to keep the `options` param in that case? Wondering because codecov is warning that w...